### PR TITLE
Add Blah type alias as union of BlahBlu and Foo in Config namespace

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ export interface Config {
 export namespace Config {
   export type BaseRequestConfig = RequestConfig;
   export type Error = AxiosError | HttpException;
+  export type Blah = BlahBlu | Foo;
 
   export type Authentication = UtilityTypes.XOR3<
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new type option within configuration settings, expanding available configuration choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->